### PR TITLE
Remove realpath dependency

### DIFF
--- a/firebase.plugin.zsh
+++ b/firebase.plugin.zsh
@@ -88,7 +88,7 @@ function get_firebase_dir() {
 				echo $dir
 				break
 		else
-				dir=$(dirname $(realpath $dir))
+				dir=$(dirname ${dir:A})
 		fi
 	done
 }


### PR DESCRIPTION
Replace the external dependency `realpath`, which is not installed in some systems, with `zsh`'s native `:A` [parameter expansion modifier](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers).

See https://github.com/robbyrussell/oh-my-zsh/pull/4106 for [apjanke](https://github.com/apjanke)'s excellent explanation.