### PR TITLE
Exact match current firebase directory in config

### DIFF
--- a/firebase.plugin.zsh
+++ b/firebase.plugin.zsh
@@ -112,7 +112,7 @@ function get_config_project_id() {
 	then
 		# May be either the project id itself or an alias (which lives in .firebaserc)
 		local target=$(get_firebase_dir)
-		echo $(grep -s $target ~/.config/configstore/firebase-tools.json | cut -d'"' -f 4)
+		echo $(grep -s \"$target\" ~/.config/configstore/firebase-tools.json | cut -d'"' -f 4)
 	fi
 }
 


### PR DESCRIPTION
Ensure the firebase project isn't being pulled from a project whose directory name is a substring of the other